### PR TITLE
Update test matrix to run on Xcode 13.3.1 and macOS 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["13.2.1", "13.1", "12.5.1", "12.4"]
+        xcode: ["13.3.1", "13.2.1", "13.1", "12.5.1", "12.4"]
         include:
+          - xcode: "13.3.1"
+            macos: macOS-12
           - xcode: "13.2.1"
             macos: macOS-11
           - xcode: "13.1"


### PR DESCRIPTION
Can't work out if it has been released or not yet...